### PR TITLE
Fix copytree for supporing python 3.8 <

### DIFF
--- a/test/NUITizenGallery/AllTest.py
+++ b/test/NUITizenGallery/AllTest.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import time
 import argparse
+from distutils.dir_util import copy_tree
 
 # Testcases list.
 def GetTCList(list):
@@ -112,8 +113,8 @@ if __name__ == '__main__':
     RunAllTest('./tclist.txt', f, currentTime, args.target)
     f.write("</html>")
     f.close()
-    shutil.copytree("./Results/TestedImages", "./Results/{}/TestedImages".format(currentTime), dirs_exist_ok=True)
-    shutil.copytree("./Results/ExpectedImages", "./Results/{}/ExpectedImages".format(currentTime), dirs_exist_ok=True)
+    copy_tree("./Results/TestedImages", "./Results/{}/TestedImages".format(currentTime))
+    copy_tree("./Results/ExpectedImages", "./Results/{}/ExpectedImages".format(currentTime))
     if os.path.islink("./Results/Latest"):
         os.remove("./Results/Latest")
         os.symlink("./Results/{}".format(currentTime), "./Results/Latest")

--- a/test/NUITizenGallery/ScreenshotCapturer.py
+++ b/test/NUITizenGallery/ScreenshotCapturer.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import datetime
 import argparse
+from distutils.dir_util import copy_tree
 
 # Testcases list.
 def GetTCList():
@@ -74,16 +75,17 @@ def RenameImageFileNames(target):
             dirName = m.group(1)
             #print(dirName)
             imageList = glob.glob("./Results/TestedImages/*")
+            print(imageList)
             for testPath in imageList:
                 print("{} copying".format(testPath))
                 destPath = "./Results/ExpectedImages/{}".format(dirName)
                 print(destPath)
-                shutil.copytree(testPath, destPath, dirs_exist_ok=True)
+                copy_tree(testPath, destPath)
                 print("removing {}".format(testPath))
                 if os.path.isdir(testPath):
                     shutil.rmtree(testPath)
 
-        shutil.copytree("./Results/ExpectedImages", "./ExpectedImages/{}".format(target), dirs_exist_ok=True)
+        copy_tree("./Results/ExpectedImages", "./ExpectedImages/{}".format(target))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
copytree with dirs_exist_ok is only possible version after python 3.8
so use copy_tree insteadly.